### PR TITLE
Fix setText failing because using incorrect WebView API

### DIFF
--- a/lib/src/editor_api.dart
+++ b/lib/src/editor_api.dart
@@ -368,7 +368,7 @@ class HtmlEditorApi {
   /// Sets the given text, replacing the previous text completely
   Future<void> setText(String text) {
     final html = _htmlEditorState.generateHtmlDocument(text);
-    return _webViewController.evaluateJavascript(source: html);
+    return _webViewController.loadData(data: html);
   }
 
   /// Selects the HTML DOM node at the current position fully.


### PR DESCRIPTION
Hello @robert-virkus and thank you for the work.

setText is not working because in this commit https://github.com/Enough-Software/enough_html_editor/commit/fb99d59cf7575e25c52b43a87a2a26f722907e02 the API used to load HTML has been changed from `loadHtmlString` to `evaluateJavascript` instead of `loadData`.

It raises errors like this one below because we send HTML string to JS handler.

`Uncaught SyntaxError: Unexpected token '<'`

## To reproduce 

Use example app (using Flutter 3.16.0 and Java 11 for me) and add in `example/lib/main.dart` at line 102:

```
PlatformTextButton(
  onPressed: () => _editorApi?.setText('New text set via setText'),
  child: const Text('Set Text'),
),
```

## Before

https://github.com/user-attachments/assets/212cbd31-37c8-4b62-8a8a-ea8b7dade2ac

## After

https://github.com/user-attachments/assets/57bbedea-d853-4047-9b07-fc452b41db27
